### PR TITLE
Api doc once over

### DIFF
--- a/lib/cumuliform/dsl.rb
+++ b/lib/cumuliform/dsl.rb
@@ -1,8 +1,14 @@
-# Simple AWS CloudFormation. Doesn't try to run the commands, doesn't try to
-# DSLize every last thing. Simple is the watch word
-
 require_relative 'template'
+require_relative 'dsl/fragments'
+require_relative 'dsl/functions'
+require_relative 'dsl/import'
+require_relative 'dsl/helpers'
 
+# Cumuliform is a simple tool for generating AWS CloudFormation templates. It's
+# concerned with making it easier and less error-prone to write templates by
+# providing features that verify references at template generation time, rather
+# than waiting for failures in stack creation. It also allows you to define and
+# reuse template fragments within one template, and between many templates.
 module Cumuliform
   # Create a new template from the passed-in block
   #
@@ -11,5 +17,16 @@ module Cumuliform
   def self.template(&block)
     template = Template.new
     template.define(&block)
+  end
+
+  # The DSL modules contain all of the public DSL methods you'll use in your templates
+  module DSL
+  end
+
+  class Template
+    include DSL::Import
+    include DSL::Fragments
+    include DSL::Functions
+    include DSL::Helpers
   end
 end

--- a/lib/cumuliform/dsl.rb
+++ b/lib/cumuliform/dsl.rb
@@ -4,6 +4,10 @@
 require_relative 'template'
 
 module Cumuliform
+  # Create a new template from the passed-in block
+  #
+  # @param block the template body
+  # @return [Template]
   def self.template(&block)
     template = Template.new
     template.define(&block)

--- a/lib/cumuliform/dsl/fragments.rb
+++ b/lib/cumuliform/dsl/fragments.rb
@@ -2,6 +2,7 @@ require_relative '../error'
 
 module Cumuliform
   module DSL
+    # DSL methods for creating and reusing template fragments
     module Fragments
       # Define a fragment for later use.
       #

--- a/lib/cumuliform/dsl/functions.rb
+++ b/lib/cumuliform/dsl/functions.rb
@@ -6,9 +6,11 @@ module Cumuliform
     module Functions
       # implements wrappers for the intrinsic functions Fn::*
       class IntrinsicFunctions
+        # @api private
         attr_reader :template
 
-        def initialize(template) # :nodoc:
+        # @api private
+        def initialize(template)
           @template = template
         end
 

--- a/lib/cumuliform/dsl/functions.rb
+++ b/lib/cumuliform/dsl/functions.rb
@@ -79,6 +79,7 @@ module Cumuliform
         #   the array of Availability Zones of. Empty string (the default) is
         #   equivalent to specifying `ref('AWS::Region')` which evaluates to
         #   the region the stack is being created in
+        # @return [Hash] the Fn::GetAZs object
         def get_azs(value = "")
           {"Fn::GetAZs" => value}
         end
@@ -135,6 +136,7 @@ module Cumuliform
         #   retrieve from <tt>array</tt>
         # @param array [Array, Hash<array-returning ref of intrinsic function>]
         #   The array to retrieve from
+        # @return [Hash] the Fn::Select object
         def select(index, array)
           ref_style_index = index.is_a?(Hash) && index.has_key?("Fn::Ref")
           positive_int_style_index = index.is_a?(Integer) && index >= 0
@@ -164,6 +166,7 @@ module Cumuliform
         # @param condition_n [Hash<boolean-returning ref, intrinsic function,
         #   or condition>] Condition / value to be ANDed (min 2, max 10
         #   condition args)
+        # @return [Hash] the Fn::And object
         def and(*conditions)
           unless (2..10).cover?(conditions.length)
             raise ArgumentError, "You must specify AT LEAST 2 and AT MOST 10 conditions"
@@ -185,6 +188,7 @@ module Cumuliform
         # @param condition_n [Hash<boolean-returning ref, intrinsic function,
         #   or condition>] Condition / value to be ORed (min 2, max 10
         #   condition args)
+        # @return [Hash] the Fn::Or object
         def or(*conditions)
           unless (2..10).cover?(conditions.length)
             raise ArgumentError, "You must specify AT LEAST 2 and AT MOST 10 conditions"
@@ -203,6 +207,7 @@ module Cumuliform
         #
         # @param condition [Hash<boolean-returning ref, intrinsic function, or
         #   condition>] Condition / value to be NOTed
+        # @return [Hash] the Fn::Not object
         def not(condition)
           {"Fn::Not" => [condition]}
         end
@@ -231,12 +236,14 @@ module Cumuliform
       # Parameter or Resource with Logical ID <tt>logical_id</tt>.
       #
       # @param logical_id [String] The logical ID of the parameter or resource
+      # @return [Hash] the Ref object
       def ref(logical_id)
         {"Ref" => xref(logical_id)}
       end
 
       # returns an instance of IntrinsicFunctions which provides wrappers for
       # Fn::* functions
+      # @return [IntrinsicFunctions] the DSL wrapper
       def fn
         @fn ||= IntrinsicFunctions.new(self)
       end

--- a/lib/cumuliform/dsl/functions.rb
+++ b/lib/cumuliform/dsl/functions.rb
@@ -2,13 +2,13 @@ require_relative '../error'
 
 module Cumuliform
   module DSL
+    # DSL methods for working with CloudFormation Intrinsic and Ref functions
     module Functions
       # implements wrappers for the intrinsic functions Fn::*
       class IntrinsicFunctions
         attr_reader :template
 
-        # @api private
-        def initialize(template)
+        def initialize(template) # :nodoc:
           @template = template
         end
 

--- a/lib/cumuliform/dsl/functions.rb
+++ b/lib/cumuliform/dsl/functions.rb
@@ -161,11 +161,12 @@ module Cumuliform
         # Arguments should be other conditions or things that will evaluate to
         # <tt>true</tt> or <tt>false</tt>.
         #
-        # @param condition_1 [Hash<boolean-returning ref, intrinsic function,
-        #   or condition>] Condition / value to be ANDed
-        # @param condition_n [Hash<boolean-returning ref, intrinsic function,
-        #   or condition>] Condition / value to be ANDed (min 2, max 10
-        #   condition args)
+        # @overload and(condition_1, ..., condition_n)
+        #   @param condition_1 [Hash<boolean-returning ref, intrinsic function,
+        #     or condition>] Condition / value to be ANDed
+        #   @param condition_n [Hash<boolean-returning ref, intrinsic function,
+        #     or condition>] Condition / value to be ANDed (min 2, max 10
+        #     condition args)
         # @return [Hash] the Fn::And object
         def and(*conditions)
           unless (2..10).cover?(conditions.length)
@@ -183,11 +184,12 @@ module Cumuliform
         # Arguments should be other conditions or things that will evaluate to
         # <tt>true</tt> or <tt>false</tt>.
         #
-        # @param condition_1 [Hash<boolean-returning ref, intrinsic function,
-        #   or condition>] Condition / value to be ORed
-        # @param condition_n [Hash<boolean-returning ref, intrinsic function,
-        #   or condition>] Condition / value to be ORed (min 2, max 10
-        #   condition args)
+        # @overload or(condition_1, ..., condition_n)
+        #   @param condition_1 [Hash<boolean-returning ref, intrinsic function,
+        #     or condition>] Condition / value to be ORed
+        #   @param condition_n [Hash<boolean-returning ref, intrinsic function,
+        #     or condition>] Condition / value to be ORed (min 2, max 10
+        #     condition args)
         # @return [Hash] the Fn::Or object
         def or(*conditions)
           unless (2..10).cover?(conditions.length)

--- a/lib/cumuliform/dsl/helpers.rb
+++ b/lib/cumuliform/dsl/helpers.rb
@@ -2,8 +2,15 @@ require_relative '../error'
 
 module Cumuliform
   module DSL
+    # Contains DSL methods for including modules containing simple helper methods
+    #
+    # Helper methods are isolated from the template object, so they can't
+    # call other DSL methods. They're really intended for wrapping code that
+    # is used in several places but requires complex setup, for example a
+    # third-party API that issues tokens you need to include in your template
+    # in some way.
     module Helpers
-      # Add helper methods to the template
+      # Add helper methods to the template.
       #
       # @overload helpers(mod, ...)
       #   Include one or more helper modules
@@ -23,10 +30,12 @@ module Cumuliform
 
       protected
 
+      # @api private
       def has_helper?(meth)
         helpers_instance.respond_to?(meth)
       end
 
+      # @api private
       def template_for_helper(meth)
         return self if has_helper?(meth)
         imports.reverse.find { |template|
@@ -34,6 +43,7 @@ module Cumuliform
         }
       end
 
+      # @api private
       def send_helper(meth, *args)
         helpers_instance.send(meth, *args)
       end

--- a/lib/cumuliform/dsl/import.rb
+++ b/lib/cumuliform/dsl/import.rb
@@ -2,6 +2,7 @@ require_relative '../error'
 
 module Cumuliform
   module DSL
+    # DSL methods for importing other templates
     module Import
       # Import another Cumuliform::Template into this one
       #

--- a/lib/cumuliform/dsl/import.rb
+++ b/lib/cumuliform/dsl/import.rb
@@ -3,16 +3,21 @@ require_relative '../error'
 module Cumuliform
   module DSL
     module Import
+      # Import another Cumuliform::Template into this one
+      #
+      # @param template [Template] the template to import
       def import(template)
         imports << template
       end
 
+      # @api private
       def has_logical_id?(logical_id)
         (imports.reverse).inject(logical_ids.include?(logical_id)) { |found, template|
           found || template.has_logical_id?(logical_id)
         }
       end
 
+      # @api private
       def verify_logical_id!(logical_id)
         raise Error::NoSuchLogicalId, logical_id unless has_logical_id?(logical_id)
         true

--- a/lib/cumuliform/error.rb
+++ b/lib/cumuliform/error.rb
@@ -1,5 +1,6 @@
 module Cumuliform
   module Error
+    # The base error class for id-related errors
     class IDError < StandardError
       attr_reader :id
 
@@ -8,36 +9,44 @@ module Cumuliform
       end
     end
 
+    # raised when a logical ID already exists
     class DuplicateLogicalID < IDError
       def to_s
         "Existing item with logical ID '#{id}'"
       end
     end
 
+    # raised when a lookup for a logical ID fails
     class NoSuchLogicalId < IDError
       def to_s
         "No such logical ID '#{id}'"
       end
     end
 
+    # raised when a Fragment with the same ID has already been defined
     class FragmentAlreadyDefined < IDError
       def to_s
         "Fragment '#{id}' already defined"
       end
     end
 
+    # raised when a Fragment lookup fails
     class FragmentNotFound < IDError
       def to_s
         "No fragment with name '#{id}'"
       end
     end
 
+    # raised when an item (e.g. Resource or Parameter) to be output contains
+    # nothing
     class EmptyItem < IDError
       def to_s
         "Empty item '#{id}'"
       end
     end
 
+    # raised when the template has no Resources defined at all (CloudFormation
+    # requires at least one resource)
     class NoResourcesDefined < StandardError
       def to_s
         "No resources defined"

--- a/lib/cumuliform/error.rb
+++ b/lib/cumuliform/error.rb
@@ -2,8 +2,12 @@ module Cumuliform
   module Error
     # The base error class for id-related errors
     class IDError < StandardError
+      # The logical ID this error refers to
       attr_reader :id
 
+      # Initialize a new IDError for the given ID
+      #
+      # @param id [String] CloudFormation logical ID
       def initialize(id)
         @id = id
       end

--- a/lib/cumuliform/error.rb
+++ b/lib/cumuliform/error.rb
@@ -11,6 +11,7 @@ module Cumuliform
 
     # raised when a logical ID already exists
     class DuplicateLogicalID < IDError
+      # returns human-readable error message
       def to_s
         "Existing item with logical ID '#{id}'"
       end
@@ -18,6 +19,7 @@ module Cumuliform
 
     # raised when a lookup for a logical ID fails
     class NoSuchLogicalId < IDError
+      # returns human-readable error message
       def to_s
         "No such logical ID '#{id}'"
       end
@@ -25,6 +27,7 @@ module Cumuliform
 
     # raised when a Fragment with the same ID has already been defined
     class FragmentAlreadyDefined < IDError
+      # returns human-readable error message
       def to_s
         "Fragment '#{id}' already defined"
       end
@@ -32,6 +35,7 @@ module Cumuliform
 
     # raised when a Fragment lookup fails
     class FragmentNotFound < IDError
+      # returns human-readable error message
       def to_s
         "No fragment with name '#{id}'"
       end
@@ -40,6 +44,7 @@ module Cumuliform
     # raised when an item (e.g. Resource or Parameter) to be output contains
     # nothing
     class EmptyItem < IDError
+      # returns human-readable error message
       def to_s
         "Empty item '#{id}'"
       end
@@ -48,6 +53,7 @@ module Cumuliform
     # raised when the template has no Resources defined at all (CloudFormation
     # requires at least one resource)
     class NoResourcesDefined < StandardError
+      # returns human-readable error message
       def to_s
         "No resources defined"
       end

--- a/lib/cumuliform/output.rb
+++ b/lib/cumuliform/output.rb
@@ -4,6 +4,8 @@
 require 'json'
 
 module Cumuliform
+  # Manages converting the Cumuliform::Template into a CloudFormation JSON
+  # string
   module Output
     # Processes the template and returns a hash representing the CloudFormation
     # template

--- a/lib/cumuliform/output.rb
+++ b/lib/cumuliform/output.rb
@@ -5,6 +5,10 @@ require 'json'
 
 module Cumuliform
   module Output
+    # Processes the template and returns a hash representing the CloudFormation
+    # template
+    #
+    # @return [Hash] Hash representing the CloudFormation template
     def to_hash
       output = {}
       SECTIONS.each do |section_name, _|
@@ -16,6 +20,10 @@ module Cumuliform
       output
     end
 
+    # Generates the JSON representation of the template from the Hash
+    # representation provided by #to_hash
+    #
+    # @return [String] JSON representation of the CloudFormation template
     def to_json
       JSON.pretty_generate(to_hash)
     end

--- a/lib/cumuliform/rake_task.rb
+++ b/lib/cumuliform/rake_task.rb
@@ -4,6 +4,8 @@ module Cumuliform
   module RakeTask
     extend self
 
+    # Rake task lib for generating Cumuliform processing rule
+    # @api private
     class TaskLib < Rake::TaskLib
       include ::Rake::DSL if defined?(::Rake::DSL)
 
@@ -16,6 +18,8 @@ module Cumuliform
       end
     end
 
+    # Define a new Rake rule task to process Cumuliform templates into
+    # CloudFormation JSON
     def rule(*args)
       TaskLib.new.define_rule(args)
     end

--- a/lib/cumuliform/rake_task.rb
+++ b/lib/cumuliform/rake_task.rb
@@ -1,6 +1,8 @@
 require 'cumuliform/runner'
 
 module Cumuliform
+  # Creates a Rake rule task for converting a Cumuliform template file into a
+  # CloudFormation JSON file
   module RakeTask
     extend self
 

--- a/lib/cumuliform/runner.rb
+++ b/lib/cumuliform/runner.rb
@@ -2,7 +2,14 @@ require 'cumuliform'
 require 'pathname'
 
 module Cumuliform
+  # The Runner class reads a template, execute it and write the generated JSON
+  # to a file
   class Runner
+    # Processes an IO object which will, when read, return a Cumuliform
+    # template file.
+    #
+    # @param io [IO] The IO-like object containing the template
+    # @return [Template] the parsed Cumuliform::Template object
     def self.process_io(io)
       mod = Module.new
       path = io.respond_to?(:path) ? io.path : nil
@@ -10,6 +17,11 @@ module Cumuliform
       template = mod.class_eval(*args)
     end
 
+    # Reads the template file at <tt>input_path</tt>, parses and executes it to generate CloudFormation JSON which is written to <tt>output_path</tt>
+    #
+    # @param input_path [String] The path to the input Cumuliform template file
+    # @param output_path [String] The path to the output CloudFormation JSON template file
+    # @return [void]
     def self.process(input_path, output_path)
       input_path = Pathname.new(input_path)
       output_path = Pathname.new(output_path)

--- a/lib/cumuliform/section.rb
+++ b/lib/cumuliform/section.rb
@@ -1,4 +1,5 @@
 module Cumuliform
+  # @api private
   class Section
     attr_reader :name, :imports, :items
 

--- a/lib/cumuliform/sections.rb
+++ b/lib/cumuliform/sections.rb
@@ -9,6 +9,7 @@ module Cumuliform
     "Outputs" => :output
   }
 
+  # @api private
   module Sections
     def initialize
       SECTIONS.each do |section_name, _|

--- a/lib/cumuliform/template.rb
+++ b/lib/cumuliform/template.rb
@@ -3,10 +3,6 @@
 
 require 'set'
 require_relative 'error'
-require_relative 'dsl/fragments'
-require_relative 'dsl/functions'
-require_relative 'dsl/import'
-require_relative 'dsl/helpers'
 require_relative 'sections'
 require_relative 'output'
 
@@ -16,24 +12,22 @@ module Cumuliform
       AWS::Region AWS::StackId AWS::StackName
   }
 
+  # Represents a single CloudFormation template
   class Template
-    include DSL::Import
-    include DSL::Fragments
-    include DSL::Functions
-    include DSL::Helpers
     include Output
     include Sections
 
+    # @api private
     def define(&block)
       instance_exec(&block)
       self
     end
 
+    private
+
     def logical_ids
       @logical_ids ||= Set.new(AWS_PSEUDO_PARAMS)
     end
-
-    private
 
     def has_local_logical_id?(logical_id)
       logical_ids.include?(logical_id)


### PR DESCRIPTION
Go through missing API docs and fix up where appropriate, adding `@api private` YARD tags where public methods are only for use internally.