### PR TITLE
require 'rake/tasklib'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=ad171accd9e47d577857f84b0d9032042ea70bf942a219bfa4f5582b5e504a60
 language: ruby
 sudo: false
 rvm:
-  2.2.2
-addons:
-  code_climate:
-    repo_token: "ad171accd9e47d577857f84b0d9032042ea70bf942a219bfa4f5582b5e504a60"
+  2.4.3
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+script:
+  - bundle exec rspec
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in cumuliform.gemspec
 gemspec
-
-gem 'codeclimate-test-reporter', group: :test, require: nil

--- a/cumuliform.gemspec
+++ b/cumuliform.gemspec
@@ -24,7 +24,8 @@ non-existent resources because you have a typo.
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "yard", ">= 0.8"
+  spec.add_development_dependency "simplecov"
 end

--- a/lib/cumuliform/rake_task.rb
+++ b/lib/cumuliform/rake_task.rb
@@ -1,3 +1,4 @@
+require 'rake/tasklib'
 require 'cumuliform/runner'
 
 module Cumuliform

--- a/lib/cumuliform/version.rb
+++ b/lib/cumuliform/version.rb
@@ -1,3 +1,3 @@
 module Cumuliform
-  VERSION = "0.5.2"
+  VERSION = "0.5.3"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 $:.unshift(File.expand_path('../lib', __dir__))
 


### PR DESCRIPTION
At some point in the last couple of years this became a non-optional
step if you wanted to subclass `Rake::TaskLib`. Correct the oversight
and explicitly require it in `lib/cumuliform/rake_task.rb`